### PR TITLE
fix: add soft link `vscode-insiders.svg`

### DIFF
--- a/links/apps/scalable/vscode-insiders.svg
+++ b/links/apps/scalable/vscode-insiders.svg
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.svg


### PR DESCRIPTION
until now the 'VSCode - Insiders' build from the Fedora Repos
provided by Microsoft uses the icon provided by the RPM Package,
because the .desktop file references the file `vscode-insiders.svg`