### PR TITLE
respect specified destination dir when cleaning old files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -286,7 +286,7 @@ clean_old_theme() {
   for theme in '' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-teal' '-grey'; do
     for scheme in '' '-nord' '-dracula'; do
       for color in '' '-light' '-dark'; do
-        rm -rf "${DEST_DIR}/${THEME_NAME}${theme}${scheme}${color}"
+        rm -rf "${dest:-${DEST_DIR}}/${THEME_NAME}${theme}${scheme}${color}"
       done
     done
   done


### PR DESCRIPTION
clean_old_theme should not touch anywhere outside of the specified destination dir. This pull request tweaks this to use the `dest` variable if it is defined.

This addresses a bunch of warnings about being unable to delete files in `/usr/share/icons...` when installing the theme into a custom directory (like when compiling the [AUR package](https://aur.archlinux.org/packages/colloid-icon-theme-git)). This also prevents removing existing theme files under `.local` if installing to a custom directory.
