### PR TITLE
Add com.mtkennerly.ludusavi alias for Ludusavi

### DIFF
--- a/links/apps/scalable/com.mtkennerly.ludusavi.svg
+++ b/links/apps/scalable/com.mtkennerly.ludusavi.svg
@@ -1,0 +1,1 @@
+com.github.mtkennerly.ludusavi.svg


### PR DESCRIPTION
The next Ludusavi release (v0.27.0) will report its app ID as `com.mtkennerly.ludusavi` instead of just `ludusavi` to be more conformant. Note that this is intentionally different from the Flatpak ID (`com.github.mtkennerly.ludusavi`), which I think is too late to change now.

I hope I've correctly added an alias for the new ID, but please let me know if this is incorrect.

More context:

* https://github.com/mtkennerly/ludusavi/pull/417
* https://github.com/mtkennerly/ludusavi/commit/0625c60b5ddc348bed8f12edea7ca17160056a51
