### PR TITLE
Fix WasIstLos icon (former 'WhatsApp for Linux')

### DIFF
--- a/links/apps/scalable/com.github.xeco23.WasIstLos.svg
+++ b/links/apps/scalable/com.github.xeco23.WasIstLos.svg
@@ -1,0 +1,1 @@
+whatsapp.svg


### PR DESCRIPTION
Preview:

![wasistlos](https://github.com/user-attachments/assets/c93df027-e348-49fc-b954-b45afa83e0d9)
