### PR TITLE
Fix typo in categories@2x/22

### DIFF
--- a/src/index.theme
+++ b/src/index.theme
@@ -280,7 +280,7 @@ MinSize=16
 MaxSize=512
 Type=Scalable
 
-[categories/22]
+[categories@2x/22]
 Size=22
 Scale=2
 Context=Categories


### PR DESCRIPTION
I use grey + everforest, and sometimes launching a gtk app emits an
error about categories@2x/22 having no size field. I mostly fixed this
using context clues, not sure if it's correct
