### PR TITLE
Add opus audio file mimetype symlink

### DIFF
--- a/links/mimetypes/scalable/audio-x-opus+ogg.svg
+++ b/links/mimetypes/scalable/audio-x-opus+ogg.svg
@@ -1,0 +1,1 @@
+application-ogg.svg


### PR DESCRIPTION
This fixes `.opus` files showing only a 16px symbolic monochrome speaker icon instead of the proper scalable file mimetype icon.

Closes #156 