### PR TITLE
Attempt to fix issue #194

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ install() {
   if [[ "${color}" == '-Dark' ]]; then
     mkdir -p                                                                                "${THEME_DIR}"/{apps,categories,devices,emblems,mimetypes,places,status}
     cp -r "${SRC_DIR}"/src/actions                                                          "${THEME_DIR}"
-    cp -r "${SRC_DIR}"/src/apps/{22,symbolic}                                               "${THEME_DIR}"/apps
+    cp -r "${SRC_DIR}"/src/apps/{22,scalable,symbolic}                                      "${THEME_DIR}"/apps
     cp -r "${SRC_DIR}"/src/categories/{22,symbolic}                                         "${THEME_DIR}"/categories
     cp -r "${SRC_DIR}"/src/emblems/symbolic                                                 "${THEME_DIR}"/emblems
     cp -r "${SRC_DIR}"/src/mimetypes/symbolic                                               "${THEME_DIR}"/mimetypes
@@ -89,7 +89,7 @@ install() {
     cp -r "${SRC_DIR}"/links/devices/{16,22,24,32,symbolic}                                 "${THEME_DIR}"/devices
     cp -r "${SRC_DIR}"/links/places/{16,22,24,scalable,symbolic}                            "${THEME_DIR}"/places
     cp -r "${SRC_DIR}"/links/status/{16,22,24,32,symbolic}                                  "${THEME_DIR}"/status
-    cp -r "${SRC_DIR}"/links/apps/{22,symbolic}                                             "${THEME_DIR}"/apps
+    cp -r "${SRC_DIR}"/links/apps/{22,scalable,symbolic}                                    "${THEME_DIR}"/apps
     cp -r "${SRC_DIR}"/links/categories/{22,symbolic}                                       "${THEME_DIR}"/categories
     cp -r "${SRC_DIR}"/links/mimetypes/symbolic                                             "${THEME_DIR}"/mimetypes
 


### PR DESCRIPTION
I made a small correction so that the files in the ```apps/scalable``` folder are copied again.

This solves this issue here: https://github.com/vinceliuice/Colloid-icon-theme/issues/194

There are two other pull requests that deserve your attention, about themes for Labwc:

https://github.com/vinceliuice/Vimix-gtk-themes/pull/284

https://github.com/vinceliuice/Matcha-gtk-theme/pull/250