### PR TITLE
fix(icons): Remove link bitwarden.svg -> revelation.svg

### DIFF
--- a/links/apps/scalable/bitwarden.svg
+++ b/links/apps/scalable/bitwarden.svg
@@ -1,1 +1,0 @@
-revelation.svg


### PR DESCRIPTION
Description:

Pull request #122 added an Bitwarden icon without removing the symbolic link to `revelation.svg`. This caused that the Bitwarden app showed an generic/1Password icon instead of the correct Bitwarden icon.

Fixes: #217 