### PR TITLE
corrected repo for tui-installer.sh

### DIFF
--- a/tui_installer.sh
+++ b/tui_installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Repository
-REPO="Burhanverse/colloid-icon-theme"
+REPO="vinceliuice/Colloid-icon-theme"
 
 # Color codes
 RED='\033[0;31m'


### PR DESCRIPTION
Was listed as "Burhanverse/colloid-icon-theme" which is 91 commits behind `vinceliuice/Colloid-icon-theme` at the time of writing, so it is corrected for those inclined to use it to ease variant installation.


## A Word of Gratitude to the Original Author (and Contributors ;] ) 

Thanks for the awesome icons and all your excellent Linux desktop theming projects. You are definitely one of the best designer working on theming Linux and thank you for offering them to the public for free and as open source. You really deserve a lot more credit for doing that.


- Thomas Leon Highbaugh