### PR TITLE
Link shared icon directories to cut install size

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,22 @@ install() {
     ln -sf status status@2x
   )
 
+  # Only the folder icons (apps, places) change with the accent color, so the
+  # other directories are identical to the default theme of the same scheme and
+  # color. Link them instead of keeping a full copy per accent variant. This is
+  # skipped when the default theme isn't installed (e.g. a single -t variant).
+  if [[ "${theme}" != '' && "${color}" != '' ]]; then
+    local BASE_DIR="${dest}/${name}${scheme}${color}"
+    if [[ -d "${BASE_DIR}" ]]; then
+      for dir in actions categories devices emblems mimetypes status; do
+        if [[ -d "${THEME_DIR}/${dir}" && ! -L "${THEME_DIR}/${dir}" ]]; then
+          rm -rf "${THEME_DIR}/${dir}"
+          ln -sf "../${name}${scheme}${color}/${dir}" "${THEME_DIR}/${dir}"
+        fi
+      done
+    fi
+  fi
+
   gtk-update-icon-cache "${THEME_DIR}"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -142,17 +142,24 @@ install() {
     ln -sf status status@2x
   )
 
-  # Only the folder icons (apps, places) change with the accent color, so the
-  # other directories are identical to the default theme of the same scheme and
-  # color. Link them instead of keeping a full copy per accent variant. This is
-  # skipped when the default theme isn't installed (e.g. a single -t variant).
-  if [[ "${theme}" != '' && "${color}" != '' ]]; then
-    local BASE_DIR="${dest}/${name}${scheme}${color}"
-    if [[ -d "${BASE_DIR}" ]]; then
+  # Only the folder icons (apps, places) change with the scheme and accent
+  # color. Every other directory is identical for all variants of the same
+  # light/dark color, so link them to the default theme instead of keeping a
+  # full copy per variant. Prefer the global default (covers -s all), fall back
+  # to the scheme default (covers a single scheme), and skip linking when no
+  # default is present so a standalone -t variant still installs in full.
+  if [[ "${color}" != '' ]]; then
+    local base=
+    if [[ ( "${theme}" != '' || "${scheme}" != '' ) && -d "${dest}/${name}${color}" ]]; then
+      base="${name}${color}"
+    elif [[ "${theme}" != '' && -d "${dest}/${name}${scheme}${color}" ]]; then
+      base="${name}${scheme}${color}"
+    fi
+    if [[ -n "${base}" ]]; then
       for dir in actions categories devices emblems mimetypes status; do
         if [[ -d "${THEME_DIR}/${dir}" && ! -L "${THEME_DIR}/${dir}" ]]; then
           rm -rf "${THEME_DIR}/${dir}"
-          ln -sf "../${name}${scheme}${color}/${dir}" "${THEME_DIR}/${dir}"
+          ln -sf "../${base}/${dir}" "${THEME_DIR}/${dir}"
         fi
       done
     fi


### PR DESCRIPTION
The accent (`-t`) and scheme (`-s`) options only change the folder icons under `apps` and `places`. Every other directory (`actions`, `categories`, `devices`, `emblems`, `mimetypes`, `status`) comes out identical for all variants of the same light/dark color, but `install.sh` copies them again for every variant. With `-t all` (and `-s all`) that means many full copies of the same icons.

This links those directories to the default theme instead of copying them:

- accent variants link to the default theme of their scheme/color
- with `-s all`, every variant links to the global default of its color, so the schemes share one copy too
- the default theme is always built first in the install loop, and when no default is present (for example a single `-t purple` install) it falls back to copying, so standalone installs keep working

Sizes:

- `-s default -t all`: 763 MB -> 259 MB
- `-s default,nord -t default,purple`: 339 MB -> 151 MB (the second scheme now shares the unchanged icons)

I verified the output is unchanged by resolving every symlink in both builds and comparing content hashes: same file set, no differences. `apps` and `places` stay real copies since they hold the colors.